### PR TITLE
feat: implement fluent API builder with TDD

### DIFF
--- a/features/core-passthrough.feature
+++ b/features/core-passthrough.feature
@@ -1,0 +1,91 @@
+Feature: Core Passthrough Behavior
+  As a developer
+  I want the core to return configured data by default
+  So that I have zero-config mocking
+
+  Scenario: Return static object data without plugins
+    Given a Schmock instance with routes:
+      """
+      {
+        "routes": {
+          "/api/users": { "data": [{"id": 1, "name": "John"}] }
+        }
+      }
+      """
+    When I process "/api/users"
+    Then I should receive:
+      """
+      [{"id": 1, "name": "John"}]
+      """
+
+  Scenario: Return string value directly
+    Given a Schmock instance with routes:
+      """
+      {
+        "routes": {
+          "/api/status": "OK"
+        }
+      }
+      """
+    When I process "/api/status"
+    Then I should receive the string "OK"
+
+  Scenario: Return number value directly
+    Given a Schmock instance with routes:
+      """
+      {
+        "routes": {
+          "/api/count": 42
+        }
+      }
+      """
+    When I process "/api/count"
+    Then I should receive the number 42
+
+  Scenario: Return boolean value directly
+    Given a Schmock instance with routes:
+      """
+      {
+        "routes": {
+          "/api/feature": true
+        }
+      }
+      """
+    When I process "/api/feature"
+    Then I should receive the boolean true
+
+  Scenario: Return null value
+    Given a Schmock instance with routes:
+      """
+      {
+        "routes": {
+          "/api/empty": null
+        }
+      }
+      """
+    When I process "/api/empty"
+    Then I should receive null
+
+  Scenario: No route found throws error
+    Given a Schmock instance with routes:
+      """
+      {
+        "routes": {
+          "/api/users": { "data": [] }
+        }
+      }
+      """
+    When I process "/api/unknown"
+    Then an error should be thrown with message "No route matches path: /api/unknown"
+
+  Scenario: Route with no data returns undefined
+    Given a Schmock instance with routes:
+      """
+      {
+        "routes": {
+          "/api/dynamic": {}
+        }
+      }
+      """
+    When I process "/api/dynamic"
+    Then I should receive undefined

--- a/features/fluent-api.feature
+++ b/features/fluent-api.feature
@@ -1,0 +1,153 @@
+Feature: Fluent API Builder
+  As a developer
+  I want to define mocks using a fluent API
+  So that I can create readable and maintainable mocks
+
+  # Design Decision: We use 'METHOD /path' string keys for routes
+  # This pattern is:
+  # - Familiar from OpenAPI/Swagger documentation
+  # - Used by modern frameworks like Hono
+  # - Enables quick visual scanning of all routes
+  # - Keeps method and path together as single source of truth
+  # - Allows copy-paste from API documentation
+  # - TypeScript validates format with template literal types
+
+  Scenario: Simple route with static response
+    Given I create a mock with:
+      """
+      schmock()
+        .routes({
+          'GET /users': {
+            response: () => [{ id: 1, name: 'John' }]
+          }
+        })
+      """
+    When I request "GET /users"
+    Then I should receive:
+      """
+      [{ "id": 1, "name": "John" }]
+      """
+
+  Scenario: Route with dynamic response and state
+    Given I create a mock with:
+      """
+      schmock()
+        .state({ count: 0 })
+        .routes({
+          'GET /counter': {
+            response: ({ state }) => {
+              state.count++;
+              return { value: state.count };
+            }
+          }
+        })
+      """
+    When I request "GET /counter" twice
+    Then the first response should have value 1
+    And the second response should have value 2
+
+  Scenario: Route with parameters
+    Given I create a mock with:
+      """
+      schmock()
+        .routes({
+          'GET /users/:id': {
+            response: ({ params }) => ({ userId: params.id })
+          }
+        })
+      """
+    When I request "GET /users/123"
+    Then I should receive:
+      """
+      { "userId": "123" }
+      """
+
+  Scenario: Response with custom status code
+    Given I create a mock with:
+      """
+      schmock()
+        .routes({
+          'POST /users': {
+            response: ({ body }) => [201, { id: 1, ...body }]
+          }
+        })
+      """
+    When I request "POST /users" with body:
+      """
+      { "name": "Alice" }
+      """
+    Then the status should be 201
+    And I should receive:
+      """
+      { "id": 1, "name": "Alice" }
+      """
+
+  Scenario: 404 for undefined routes
+    Given I create a mock with:
+      """
+      schmock()
+        .routes({
+          'GET /users': {
+            response: () => []
+          }
+        })
+      """
+    When I request "GET /posts"
+    Then the status should be 404
+
+  Scenario: Query parameters
+    Given I create a mock with:
+      """
+      schmock()
+        .routes({
+          'GET /search': {
+            response: ({ query }) => ({ 
+              results: [], 
+              query: query.q 
+            })
+          }
+        })
+      """
+    When I request "GET /search?q=test"
+    Then I should receive:
+      """
+      { "results": [], "query": "test" }
+      """
+
+  Scenario: Request headers access
+    Given I create a mock with:
+      """
+      schmock()
+        .routes({
+          'GET /auth': {
+            response: ({ headers }) => ({ 
+              authenticated: headers.authorization === 'Bearer token123' 
+            })
+          }
+        })
+      """
+    When I request "GET /auth" with headers:
+      """
+      { "authorization": "Bearer token123" }
+      """
+    Then I should receive:
+      """
+      { "authenticated": true }
+      """
+
+  Scenario: Configuration with namespace
+    Given I create a mock with:
+      """
+      schmock()
+        .config({ namespace: '/api/v1' })
+        .routes({
+          'GET /users': {
+            response: () => []
+          }
+        })
+      """
+    When I request "GET /api/v1/users"
+    Then I should receive:
+      """
+      []
+      """

--- a/features/route-key-format.feature
+++ b/features/route-key-format.feature
@@ -1,0 +1,74 @@
+Feature: Route Key Format
+  As a developer
+  I want to use 'METHOD /path' format for route keys
+  So that I have a consistent and readable API
+
+  # DX Design Choice:
+  # We chose 'METHOD /path' string format over alternatives like:
+  # - Nested objects: { '/users': { GET: {...} } } - too much nesting
+  # - Method chaining: .get('/users', ...) - less declarative
+  # - Array format: [{ method: 'GET', path: '/users' }] - too verbose
+  #
+  # Benefits of 'METHOD /path':
+  # - Matches OpenAPI/Swagger format
+  # - Single line per route for easy scanning
+  # - Natural reading: "GET /users returns..."
+  # - TypeScript can validate with template literal types
+
+  Scenario Outline: Valid route key formats
+    When I parse route key "<key>"
+    Then the method should be "<method>"
+    And the path should be "<path>"
+    
+    Examples:
+      | key                        | method | path                       |
+      | GET /users                 | GET    | /users                     |
+      | POST /api/users            | POST   | /api/users                 |
+      | DELETE /users/:id          | DELETE | /users/:id                 |
+      | PUT /posts/:id/publish     | PUT    | /posts/:id/publish         |
+      | PATCH /settings            | PATCH  | /settings                  |
+      | HEAD /health               | HEAD   | /health                    |
+      | OPTIONS /users             | OPTIONS| /users                     |
+
+  Scenario Outline: Invalid route key formats
+    When I parse route key "<key>"
+    Then an error should be thrown with message matching "<error>"
+    
+    Examples:
+      | key           | error                                    |
+      | /users        | Invalid route key format                 |
+      | GET           | Invalid route key format                 |
+      | INVALID /path | Invalid route key format                 |
+      | get /users    | Invalid route key format                 |
+      | GET/users     | Invalid route key format                 |
+
+  Scenario: Extract parameters from path
+    When I parse route key "GET /users/:userId/posts/:postId"
+    Then the method should be "GET"
+    And the path should be "/users/:userId/posts/:postId"
+    And the parameters should be:
+      """
+      ["userId", "postId"]
+      """
+
+  Scenario: No parameters in simple path
+    When I parse route key "GET /users"
+    Then the parameters should be:
+      """
+      []
+      """
+
+  Scenario: Path with query string placeholder
+    When I parse route key "GET /search"
+    Then the method should be "GET"
+    And the path should be "/search"
+    And query parameters are handled separately at runtime
+
+  Scenario: Complex nested paths
+    When I parse route key "DELETE /api/v2/organizations/:orgId/teams/:teamId/members/:userId"
+    Then the method should be "DELETE"
+    And the path should be "/api/v2/organizations/:orgId/teams/:teamId/members/:userId"
+    And the parameters should be:
+      """
+      ["orgId", "teamId", "userId"]
+      """

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@schmock/builder",
+  "description": "Fluent API builder for Schmock",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "bun build:lib && bun build:types",
+    "build:lib": "bun build --minify --outdir=dist src/index.ts",
+    "build:types": "tsc -p tsconfig.json",
+    "test": "vitest",
+    "test:watch": "vitest --watch",
+    "test:bdd": "vitest run --config vitest.config.bdd.ts",
+    "lint": "biome check src/*.ts",
+    "lint:fix": "biome check --write --unsafe src/*.ts"
+  },
+  "license": "MIT",
+  "devDependencies": {
+    "@amiceli/vitest-cucumber": "^5.1.2",
+    "@types/node": "^24.1.0",
+    "@vitest/ui": "^3.2.4",
+    "vitest": "^3.2.4"
+  }
+}

--- a/packages/builder/src/builder.test.ts
+++ b/packages/builder/src/builder.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect } from 'vitest'
+import { schmock } from './index'
+import type { Builder, MockInstance } from './types'
+
+describe('schmock builder', () => {
+  describe('fluent API', () => {
+    it('returns builder instance from factory', () => {
+      const builder = schmock()
+      expect(builder).toBeDefined()
+      expect(builder.config).toBeTypeOf('function')
+      expect(builder.routes).toBeTypeOf('function')
+      expect(builder.state).toBeTypeOf('function')
+      expect(builder.use).toBeTypeOf('function')
+      expect(builder.build).toBeTypeOf('function')
+    })
+
+    it('chains method calls fluently', () => {
+      const builder = schmock()
+        .config({ namespace: '/api' })
+        .routes({
+          'GET /users': {
+            response: () => []
+          }
+        })
+        .state({ count: 0 })
+      
+      expect(builder).toBeDefined()
+      expect(builder.build).toBeTypeOf('function')
+    })
+
+    it('builds mock instance', () => {
+      const mock = schmock()
+        .routes({
+          'GET /users': {
+            response: () => []
+          }
+        })
+        .build()
+      
+      expect(mock).toBeDefined()
+      expect(mock.handle).toBeTypeOf('function')
+    })
+  })
+
+  describe('request handling', () => {
+    it('handles simple GET request', async () => {
+      const mock = schmock()
+        .routes({
+          'GET /users': {
+            response: () => [{ id: 1, name: 'John' }]
+          }
+        })
+        .build()
+      
+      const response = await mock.handle('GET', '/users')
+      
+      expect(response.status).toBe(200)
+      expect(response.body).toEqual([{ id: 1, name: 'John' }])
+      expect(response.headers).toEqual({})
+    })
+
+    it('returns 404 for undefined routes', async () => {
+      const mock = schmock()
+        .routes({
+          'GET /users': {
+            response: () => []
+          }
+        })
+        .build()
+      
+      const response = await mock.handle('GET', '/posts')
+      
+      expect(response.status).toBe(404)
+    })
+
+    it('handles route with parameters', async () => {
+      const mock = schmock()
+        .routes({
+          'GET /users/:id': {
+            response: ({ params }) => ({ userId: params.id })
+          }
+        })
+        .build()
+      
+      const response = await mock.handle('GET', '/users/123')
+      
+      expect(response.status).toBe(200)
+      expect(response.body).toEqual({ userId: '123' })
+    })
+
+    it('handles custom status codes via tuple', async () => {
+      const mock = schmock()
+        .routes({
+          'POST /users': {
+            response: ({ body }) => [201, { id: 1, ...body }]
+          }
+        })
+        .build()
+      
+      const response = await mock.handle('POST', '/users', {
+        body: { name: 'Alice' }
+      })
+      
+      expect(response.status).toBe(201)
+      expect(response.body).toEqual({ id: 1, name: 'Alice' })
+    })
+
+    it('handles custom headers via triple tuple', async () => {
+      const mock = schmock()
+        .routes({
+          'POST /users': {
+            response: ({ body }) => [
+              201, 
+              { id: 1, ...body },
+              { 'Location': '/users/1' }
+            ]
+          }
+        })
+        .build()
+      
+      const response = await mock.handle('POST', '/users', {
+        body: { name: 'Alice' }
+      })
+      
+      expect(response.status).toBe(201)
+      expect(response.headers).toEqual({ 'Location': '/users/1' })
+    })
+  })
+
+  describe('state management', () => {
+    it('maintains state across requests', async () => {
+      const mock = schmock()
+        .state({ count: 0 })
+        .routes({
+          'GET /increment': {
+            response: ({ state }) => {
+              state.count++
+              return { value: state.count }
+            }
+          }
+        })
+        .build()
+      
+      const first = await mock.handle('GET', '/increment')
+      const second = await mock.handle('GET', '/increment')
+      
+      expect(first.body).toEqual({ value: 1 })
+      expect(second.body).toEqual({ value: 2 })
+    })
+
+    it('shares state between routes', async () => {
+      const mock = schmock()
+        .state({ users: [] as any[] })
+        .routes({
+          'POST /users': {
+            response: ({ body, state }) => {
+              const user = { id: Date.now(), ...body }
+              state.users.push(user)
+              return [201, user]
+            }
+          },
+          'GET /users': {
+            response: ({ state }) => state.users
+          }
+        })
+        .build()
+      
+      await mock.handle('POST', '/users', { body: { name: 'John' } })
+      const response = await mock.handle('GET', '/users')
+      
+      expect(response.body).toHaveLength(1)
+      expect(response.body[0]).toHaveProperty('name', 'John')
+    })
+  })
+
+  describe('configuration', () => {
+    it('applies namespace to all routes', async () => {
+      const mock = schmock()
+        .config({ namespace: '/api/v1' })
+        .routes({
+          'GET /users': {
+            response: () => []
+          }
+        })
+        .build()
+      
+      const response = await mock.handle('GET', '/api/v1/users')
+      
+      expect(response.status).toBe(200)
+      expect(response.body).toEqual([])
+    })
+
+    it('returns 404 without namespace prefix', async () => {
+      const mock = schmock()
+        .config({ namespace: '/api/v1' })
+        .routes({
+          'GET /users': {
+            response: () => []
+          }
+        })
+        .build()
+      
+      const response = await mock.handle('GET', '/users')
+      
+      expect(response.status).toBe(404)
+    })
+  })
+
+  describe('request context', () => {
+    it('provides query parameters', async () => {
+      const mock = schmock()
+        .routes({
+          'GET /search': {
+            response: ({ query }) => ({ 
+              results: [],
+              query: query.q 
+            })
+          }
+        })
+        .build()
+      
+      const response = await mock.handle('GET', '/search', {
+        query: { q: 'test' }
+      })
+      
+      expect(response.body).toEqual({ 
+        results: [],
+        query: 'test'
+      })
+    })
+
+    it('provides headers', async () => {
+      const mock = schmock()
+        .routes({
+          'GET /auth': {
+            response: ({ headers }) => ({ 
+              authenticated: headers.authorization === 'Bearer token123' 
+            })
+          }
+        })
+        .build()
+      
+      const response = await mock.handle('GET', '/auth', {
+        headers: { authorization: 'Bearer token123' }
+      })
+      
+      expect(response.body).toEqual({ authenticated: true })
+    })
+
+    it('provides method and path in context', async () => {
+      const mock = schmock()
+        .routes({
+          'GET /info': {
+            response: ({ method, path }) => ({ method, path })
+          }
+        })
+        .build()
+      
+      const response = await mock.handle('GET', '/info')
+      
+      expect(response.body).toEqual({ 
+        method: 'GET',
+        path: '/info'
+      })
+    })
+  })
+})

--- a/packages/builder/src/builder.ts
+++ b/packages/builder/src/builder.ts
@@ -1,0 +1,191 @@
+import type { 
+  Builder, 
+  BuilderConfig, 
+  Routes, 
+  MockInstance,
+  RouteDefinition,
+  ResponseContext,
+  HttpMethod
+} from './types'
+import { parseRouteKey } from './parser'
+import type { ParsedRoute } from './parser'
+
+interface BuilderState<TState> {
+  config?: BuilderConfig
+  routes?: Routes<TState>
+  state?: TState
+  plugins: any[]
+}
+
+interface CompiledRoute<TState> extends ParsedRoute {
+  definition: RouteDefinition<TState>
+}
+
+/**
+ * Fluent builder for creating Schmock instances.
+ * 
+ * @internal
+ */
+export class SchmockBuilder<TState = any> implements Builder<TState> {
+  private options: BuilderState<TState> = {
+    plugins: []
+  }
+
+  config(options: BuilderConfig): Builder<TState> {
+    this.options.config = { ...this.options.config, ...options }
+    return this
+  }
+
+  routes(routes: Routes<TState>): Builder<TState> {
+    this.options.routes = { ...this.options.routes, ...routes }
+    return this
+  }
+
+  state<T>(initial: T): Builder<T> {
+    const newBuilder = new SchmockBuilder<T>()
+    newBuilder.options = {
+      ...this.options,
+      state: initial
+    } as BuilderState<T>
+    return newBuilder
+  }
+
+  use(plugin: any): Builder<TState> {
+    this.options.plugins.push(plugin)
+    return this
+  }
+
+  build(): MockInstance<TState> {
+    const compiledRoutes = this.compileRoutes()
+    const state = this.options.state
+    const config = this.options.config || {}
+
+    return new SchmockInstance(compiledRoutes, state, config)
+  }
+
+  /**
+   * Compile route definitions into parsed routes with patterns.
+   * Applies namespace prefix if configured.
+   */
+  private compileRoutes(): CompiledRoute<TState>[] {
+    const routes = this.options.routes || {}
+    const namespace = this.options.config?.namespace || ''
+    
+    return Object.entries(routes).map(([routeKey, definition]) => {
+      const parsed = parseRouteKey(routeKey)
+      
+      // Apply namespace if configured
+      if (namespace) {
+        parsed.path = namespace + parsed.path
+        // Rebuild pattern with namespace
+        const regexPath = parsed.path
+          .replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+          .replace(/:([^/]+)/g, '([^/]+)')
+        parsed.pattern = new RegExp(`^${regexPath}$`)
+      }
+      
+      return {
+        ...parsed,
+        definition: definition!
+      }
+    })
+  }
+}
+
+/**
+ * Mock instance that handles requests based on configured routes.
+ * 
+ * @internal
+ */
+class SchmockInstance<TState> implements MockInstance<TState> {
+  constructor(
+    private routes: CompiledRoute<TState>[],
+    private state: TState,
+    private config: BuilderConfig
+  ) {}
+
+  async handle(
+    method: HttpMethod, 
+    path: string, 
+    options?: {
+      headers?: Record<string, string>
+      body?: any
+      query?: Record<string, string>
+    }
+  ): Promise<{
+    status: number
+    body: any
+    headers: Record<string, string>
+  }> {
+    // Find matching route
+    const route = this.findRoute(method, path)
+    
+    if (!route) {
+      return {
+        status: 404,
+        body: { error: 'Not Found' },
+        headers: {}
+      }
+    }
+
+    // Extract params from path
+    const params = this.extractParams(route, path)
+
+    // Build context
+    const context: ResponseContext<TState> = {
+      state: this.state,
+      params,
+      query: options?.query || {},
+      body: options?.body,
+      headers: options?.headers || {},
+      method,
+      path
+    }
+
+    // Execute response function
+    const result = await route.definition.response(context)
+
+    // Parse result
+    if (Array.isArray(result)) {
+      // Check if it's a tuple response [status, body, headers?]
+      if (typeof result[0] === 'number') {
+        const [status, body, headers] = result
+        return {
+          status,
+          body,
+          headers: headers || {}
+        }
+      }
+    }
+
+    return {
+      status: 200,
+      body: result,
+      headers: {}
+    }
+  }
+
+  /**
+   * Find a route that matches the given method and path.
+   */
+  private findRoute(method: HttpMethod, path: string): CompiledRoute<TState> | undefined {
+    return this.routes.find(route => 
+      route.method === method && route.pattern.test(path)
+    )
+  }
+
+  /**
+   * Extract parameter values from the path based on the route pattern.
+   */
+  private extractParams(route: CompiledRoute<TState>, path: string): Record<string, string> {
+    const match = path.match(route.pattern)
+    if (!match) return {}
+
+    const params: Record<string, string> = {}
+    route.params.forEach((param, index) => {
+      params[param] = match[index + 1]
+    })
+
+    return params
+  }
+}

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -1,0 +1,38 @@
+import { SchmockBuilder } from './builder'
+import type { Builder } from './types'
+
+/**
+ * Create a new Schmock mock builder.
+ * 
+ * @example
+ * ```typescript
+ * const mock = schmock()
+ *   .routes({
+ *     'GET /users': {
+ *       response: () => [{ id: 1, name: 'John' }]
+ *     }
+ *   })
+ *   .build()
+ * 
+ * const response = await mock.handle('GET', '/users')
+ * ```
+ * 
+ * @returns A new builder instance
+ */
+export function schmock(): Builder {
+  return new SchmockBuilder()
+}
+
+// Re-export types
+export type { 
+  Builder,
+  MockInstance,
+  ResponseContext,
+  ResponseResult,
+  ResponseFunction,
+  RouteDefinition,
+  Routes,
+  BuilderConfig,
+  HttpMethod,
+  RouteKey
+} from './types'

--- a/packages/builder/src/parser.test.ts
+++ b/packages/builder/src/parser.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest'
+import { parseRouteKey } from './parser'
+
+describe('parseRouteKey', () => {
+  describe('valid route keys', () => {
+    it('parses simple GET route', () => {
+      const result = parseRouteKey('GET /users')
+      expect(result).toEqual({
+        method: 'GET',
+        path: '/users',
+        pattern: expect.any(RegExp),
+        params: []
+      })
+    })
+
+    it('parses route with single parameter', () => {
+      const result = parseRouteKey('GET /users/:id')
+      expect(result).toEqual({
+        method: 'GET',
+        path: '/users/:id',
+        pattern: expect.any(RegExp),
+        params: ['id']
+      })
+    })
+
+    it('parses route with multiple parameters', () => {
+      const result = parseRouteKey('DELETE /api/posts/:postId/comments/:commentId')
+      expect(result).toEqual({
+        method: 'DELETE',
+        path: '/api/posts/:postId/comments/:commentId',
+        pattern: expect.any(RegExp),
+        params: ['postId', 'commentId']
+      })
+    })
+
+    it('supports all HTTP methods', () => {
+      const methods = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS'] as const
+      
+      for (const method of methods) {
+        const result = parseRouteKey(`${method} /test`)
+        expect(result.method).toBe(method)
+      }
+    })
+
+    it('handles paths with namespace', () => {
+      const result = parseRouteKey('POST /api/v2/users')
+      expect(result).toEqual({
+        method: 'POST',
+        path: '/api/v2/users',
+        pattern: expect.any(RegExp),
+        params: []
+      })
+    })
+
+    it('creates correct regex pattern for simple path', () => {
+      const result = parseRouteKey('GET /users')
+      expect('/users').toMatch(result.pattern)
+      expect('/users/123').not.toMatch(result.pattern)
+    })
+
+    it('creates correct regex pattern with parameters', () => {
+      const result = parseRouteKey('GET /users/:id')
+      expect('/users/123').toMatch(result.pattern)
+      expect('/users/abc-def').toMatch(result.pattern)
+      expect('/users').not.toMatch(result.pattern)
+      expect('/users/').not.toMatch(result.pattern)
+      expect('/users/123/posts').not.toMatch(result.pattern)
+    })
+  })
+
+  describe('invalid route keys', () => {
+    it('throws on missing method', () => {
+      expect(() => parseRouteKey('/users')).toThrow('Invalid route key format')
+    })
+
+    it('throws on missing path', () => {
+      expect(() => parseRouteKey('GET')).toThrow('Invalid route key format')
+    })
+
+    it('throws on invalid method', () => {
+      expect(() => parseRouteKey('INVALID /users')).toThrow('Invalid route key format')
+    })
+
+    it('throws on lowercase method', () => {
+      expect(() => parseRouteKey('get /users')).toThrow('Invalid route key format')
+    })
+
+    it('throws on missing space', () => {
+      expect(() => parseRouteKey('GET/users')).toThrow('Invalid route key format')
+    })
+
+    it('throws on empty string', () => {
+      expect(() => parseRouteKey('')).toThrow('Invalid route key format')
+    })
+  })
+
+  describe('parameter extraction', () => {
+    it('extracts matched parameters', () => {
+      const route = parseRouteKey('GET /users/:userId/posts/:postId')
+      const match = '/users/123/posts/456'.match(route.pattern)
+      
+      expect(match).toBeTruthy()
+      expect(match![1]).toBe('123')
+      expect(match![2]).toBe('456')
+    })
+
+    it('handles special characters in parameters', () => {
+      const route = parseRouteKey('GET /files/:filename')
+      const match = '/files/report-2023.pdf'.match(route.pattern)
+      
+      expect(match).toBeTruthy()
+      expect(match![1]).toBe('report-2023.pdf')
+    })
+  })
+})

--- a/packages/builder/src/parser.ts
+++ b/packages/builder/src/parser.ts
@@ -1,0 +1,56 @@
+import type { HttpMethod } from './types'
+
+export interface ParsedRoute {
+  method: HttpMethod
+  path: string
+  pattern: RegExp
+  params: string[]
+}
+
+/**
+ * Parse 'METHOD /path' route key format
+ * 
+ * Design note: We validate the format strictly to catch typos early.
+ * The 'METHOD /path' format was chosen for its readability and
+ * similarity to API documentation formats.
+ * 
+ * @example
+ * parseRouteKey('GET /users/:id') 
+ * // => { method: 'GET', path: '/users/:id', pattern: /^\/users\/([^/]+)$/, params: ['id'] }
+ */
+export function parseRouteKey(routeKey: string): ParsedRoute {
+  const match = routeKey.match(/^(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS) (.+)$/)
+  
+  if (!match) {
+    throw new Error(
+      `Invalid route key format: "${routeKey}". ` +
+      `Expected format: "METHOD /path" (e.g., "GET /users")`
+    )
+  }
+  
+  const [, method, path] = match
+  
+  // Extract parameter names
+  const params: string[] = []
+  const paramPattern = /:([^/]+)/g
+  let paramMatch: RegExpExecArray | null
+  
+  while ((paramMatch = paramPattern.exec(path)) !== null) {
+    params.push(paramMatch[1])
+  }
+  
+  // Build regex pattern for matching
+  // Replace :param with capture groups
+  const regexPath = path
+    .replace(/[.*+?^${}()|[\]\\]/g, '\\$&') // Escape special regex chars except :
+    .replace(/:([^/]+)/g, '([^/]+)')         // Replace :param with capture group
+  
+  const pattern = new RegExp(`^${regexPath}$`)
+  
+  return {
+    method: method satisfies HttpMethod,
+    path,
+    pattern,
+    params
+  }
+}

--- a/packages/builder/src/steps/fluent-api.steps.ts
+++ b/packages/builder/src/steps/fluent-api.steps.ts
@@ -1,0 +1,174 @@
+import { loadFeature, describeFeature } from '@amiceli/vitest-cucumber'
+import { expect } from 'vitest'
+import { schmock } from '../index'
+import type { MockInstance } from '../types'
+
+const feature = await loadFeature('../../features/fluent-api.feature')
+
+describeFeature(feature, ({ Scenario }) => {
+  let mock: MockInstance<any>
+  let response: any
+  let responses: any[] = []
+  let error: Error | null = null
+
+  Scenario('Simple route with static response', ({ Given, When, Then }) => {
+    Given('I create a mock with:', (_, docString: string) => {
+      // Evaluate the code string to create the mock
+      // In a real implementation, we'd parse this more carefully
+      const createMock = new Function('schmock', `return ${docString}`)
+      mock = createMock(schmock).build()
+    })
+
+    When('I request {string}', async (_, request: string) => {
+      const [method, path] = request.split(' ')
+      response = await mock.handle(method as any, path)
+    })
+
+    Then('I should receive:', (_, docString: string) => {
+      const expected = JSON.parse(docString)
+      expect(response.body).toEqual(expected)
+    })
+  })
+
+  Scenario('Route with dynamic response and state', ({ Given, When, Then, And }) => {
+    responses = []
+    
+    Given('I create a mock with:', (_, docString: string) => {
+      const createMock = new Function('schmock', `return ${docString}`)
+      mock = createMock(schmock).build()
+    })
+
+    When('I request {string} twice', async (_, request: string) => {
+      const [method, path] = request.split(' ')
+      responses = []
+      responses.push(await mock.handle(method as any, path))
+      responses.push(await mock.handle(method as any, path))
+    })
+
+    Then('the first response should have value {int}', (_, value: number) => {
+      expect(responses[0].body).toEqual({ value })
+    })
+
+    And('the second response should have value {int}', (_, value: number) => {
+      expect(responses[1].body).toEqual({ value })
+    })
+  })
+
+  Scenario('Route with parameters', ({ Given, When, Then }) => {
+    Given('I create a mock with:', (_, docString: string) => {
+      const createMock = new Function('schmock', `return ${docString}`)
+      mock = createMock(schmock).build()
+    })
+
+    When('I request {string}', async (_, request: string) => {
+      const [method, path] = request.split(' ')
+      response = await mock.handle(method as any, path)
+    })
+
+    Then('I should receive:', (_, docString: string) => {
+      const expected = JSON.parse(docString)
+      expect(response.body).toEqual(expected)
+    })
+  })
+
+  Scenario('Response with custom status code', ({ Given, When, Then, And }) => {
+    Given('I create a mock with:', (_, docString: string) => {
+      const createMock = new Function('schmock', `return ${docString}`)
+      mock = createMock(schmock).build()
+    })
+
+    When('I request {string} with body:', async (_, request: string, docString: string) => {
+      const [method, path] = request.split(' ')
+      const body = JSON.parse(docString)
+      response = await mock.handle(method as any, path, { body })
+    })
+
+    Then('the status should be {int}', (_, status: number) => {
+      expect(response.status).toBe(status)
+    })
+
+    And('I should receive:', (_, docString: string) => {
+      const expected = JSON.parse(docString)
+      expect(response.body).toEqual(expected)
+    })
+  })
+
+  Scenario('404 for undefined routes', ({ Given, When, Then }) => {
+    Given('I create a mock with:', (_, docString: string) => {
+      const createMock = new Function('schmock', `return ${docString}`)
+      mock = createMock(schmock).build()
+    })
+
+    When('I request {string}', async (_, request: string) => {
+      const [method, path] = request.split(' ')
+      response = await mock.handle(method as any, path)
+    })
+
+    Then('the status should be {int}', (_, status: number) => {
+      expect(response.status).toBe(status)
+    })
+  })
+
+  Scenario('Query parameters', ({ Given, When, Then }) => {
+    Given('I create a mock with:', (_, docString: string) => {
+      const createMock = new Function('schmock', `return ${docString}`)
+      mock = createMock(schmock).build()
+    })
+
+    When('I request {string}', async (_, request: string) => {
+      const [method, fullPath] = request.split(' ')
+      const [path, queryString] = fullPath.split('?')
+      
+      // Parse query string
+      const query: Record<string, string> = {}
+      if (queryString) {
+        queryString.split('&').forEach(param => {
+          const [key, value] = param.split('=')
+          query[key] = value
+        })
+      }
+      
+      response = await mock.handle(method as any, path, { query })
+    })
+
+    Then('I should receive:', (_, docString: string) => {
+      const expected = JSON.parse(docString)
+      expect(response.body).toEqual(expected)
+    })
+  })
+
+  Scenario('Request headers access', ({ Given, When, Then }) => {
+    Given('I create a mock with:', (_, docString: string) => {
+      const createMock = new Function('schmock', `return ${docString}`)
+      mock = createMock(schmock).build()
+    })
+
+    When('I request {string} with headers:', async (_, request: string, docString: string) => {
+      const [method, path] = request.split(' ')
+      const headers = JSON.parse(docString)
+      response = await mock.handle(method as any, path, { headers })
+    })
+
+    Then('I should receive:', (_, docString: string) => {
+      const expected = JSON.parse(docString)
+      expect(response.body).toEqual(expected)
+    })
+  })
+
+  Scenario('Configuration with namespace', ({ Given, When, Then }) => {
+    Given('I create a mock with:', (_, docString: string) => {
+      const createMock = new Function('schmock', `return ${docString}`)
+      mock = createMock(schmock).build()
+    })
+
+    When('I request {string}', async (_, request: string) => {
+      const [method, path] = request.split(' ')
+      response = await mock.handle(method as any, path)
+    })
+
+    Then('I should receive:', (_, docString: string) => {
+      const expected = JSON.parse(docString)
+      expect(response.body).toEqual(expected)
+    })
+  })
+})

--- a/packages/builder/src/steps/route-key-format.steps.ts
+++ b/packages/builder/src/steps/route-key-format.steps.ts
@@ -1,0 +1,115 @@
+import { loadFeature, describeFeature } from '@amiceli/vitest-cucumber'
+import { expect } from 'vitest'
+import { parseRouteKey } from '../parser'
+import type { ParsedRoute } from '../parser'
+
+const feature = await loadFeature('../../features/route-key-format.feature')
+
+describeFeature(feature, ({ Scenario, ScenarioOutline }) => {
+  let result: ParsedRoute
+  let error: Error | null = null
+
+  ScenarioOutline('Valid route key formats', ({ When, Then, And }, variables) => {
+    When('I parse route key {string}', () => {
+      error = null
+      try {
+        result = parseRouteKey(variables.key)
+      } catch (e) {
+        error = e as Error
+      }
+    })
+
+    Then('the method should be {string}', () => {
+      expect(error).toBeNull()
+      expect(result.method).toBe(variables.method)
+    })
+
+    And('the path should be {string}', () => {
+      expect(result.path).toBe(variables.path)
+    })
+  })
+
+  ScenarioOutline('Invalid route key formats', ({ When, Then }, variables) => {
+    When('I parse route key {string}', () => {
+      error = null
+      try {
+        result = parseRouteKey(variables.key)
+      } catch (e) {
+        error = e as Error
+      }
+    })
+
+    Then('an error should be thrown with message matching {string}', () => {
+      expect(error).not.toBeNull()
+      expect(error!.message).toMatch(variables.error)
+    })
+  })
+
+  Scenario('Extract parameters from path', ({ When, Then, And }) => {
+    When('I parse route key {string}', (_, routeKey: string) => {
+      result = parseRouteKey(routeKey)
+    })
+
+    Then('the method should be {string}', (_, expectedMethod: string) => {
+      expect(result.method).toBe(expectedMethod)
+    })
+
+    And('the path should be {string}', (_, expectedPath: string) => {
+      expect(result.path).toBe(expectedPath)
+    })
+
+    And('the parameters should be:', (_, docString: string) => {
+      const expectedParams = JSON.parse(docString)
+      expect(result.params).toEqual(expectedParams)
+    })
+  })
+
+  Scenario('No parameters in simple path', ({ When, Then }) => {
+    When('I parse route key {string}', (_, routeKey: string) => {
+      result = parseRouteKey(routeKey)
+    })
+
+    Then('the parameters should be:', (_, docString: string) => {
+      const expectedParams = JSON.parse(docString)
+      expect(result.params).toEqual(expectedParams)
+    })
+  })
+
+  Scenario('Path with query string placeholder', ({ When, Then, And }) => {
+    When('I parse route key {string}', (_, routeKey: string) => {
+      result = parseRouteKey(routeKey)
+    })
+
+    Then('the method should be {string}', (_, expectedMethod: string) => {
+      expect(result.method).toBe(expectedMethod)
+    })
+
+    And('the path should be {string}', (_, expectedPath: string) => {
+      expect(result.path).toBe(expectedPath)
+    })
+
+    And('query parameters are handled separately at runtime', () => {
+      // This is a documentation scenario - query params are not part of the route key
+      expect(result.path).not.toContain('?')
+    })
+  })
+
+  Scenario('Complex nested paths', ({ When, Then, And }) => {
+    When('I parse route key {string}', (_, routeKey: string) => {
+      result = parseRouteKey(routeKey)
+    })
+
+    Then('the method should be {string}', (_, expectedMethod: string) => {
+      expect(result.method).toBe(expectedMethod)
+    })
+
+    And('the path should be {string}', (_, expectedPath: string) => {
+      expect(result.path).toBe(expectedPath)
+    })
+
+    And('the parameters should be:', (_, docString: string) => {
+      const expectedParams = JSON.parse(docString)
+      expect(result.params).toEqual(expectedParams)
+    })
+  })
+})

--- a/packages/builder/src/types.ts
+++ b/packages/builder/src/types.ts
@@ -1,0 +1,13 @@
+/// <reference path="../../../types/schmock.d.ts" />
+
+// Re-export fluent API types for internal use
+export type HttpMethod = Schmock.HttpMethod;
+export type RouteKey = Schmock.RouteKey;
+export type BuilderConfig = Schmock.BuilderConfig;
+export type ResponseContext<T = any> = Schmock.ResponseContext<T>;
+export type ResponseResult = Schmock.ResponseResult;
+export type ResponseFunction<T = any> = Schmock.ResponseFunction<T>;
+export type RouteDefinition<T = any> = Schmock.RouteDefinition<T>;
+export type Routes<T = any> = Schmock.Routes<T>;
+export type Builder<T = any> = Schmock.Builder<T>;
+export type MockInstance<T = any> = Schmock.MockInstance<T>;

--- a/packages/builder/tsconfig.json
+++ b/packages/builder/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "composite": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.steps.ts"]
+}

--- a/packages/builder/vitest.config.bdd.ts
+++ b/packages/builder/vitest.config.bdd.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.steps.ts'],
+    reporters: ['default'],
+  },
+})

--- a/packages/builder/vitest.config.ts
+++ b/packages/builder/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    exclude: ['**/*.steps.ts']
+  },
+})

--- a/types/schmock.d.ts
+++ b/types/schmock.d.ts
@@ -4,6 +4,27 @@
  */
 declare namespace Schmock {
   /**
+   * HTTP methods supported by Schmock
+   */
+  type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'HEAD' | 'OPTIONS'
+  
+  /**
+   * Route key format: 'METHOD /path'
+   * 
+   * @example
+   * 'GET /users'
+   * 'POST /users/:id'
+   * 'DELETE /api/posts/:postId/comments/:commentId'
+   * 
+   * Design rationale:
+   * - Combines method and path in a single, scannable string
+   * - Matches OpenAPI/Swagger documentation format
+   * - Enables copy-paste from API docs
+   * - TypeScript validates format at compile time
+   * - Used by modern frameworks like Hono
+   */
+  type RouteKey = `${HttpMethod} ${string}`
+  /**
    * Main configuration object for Schmock instance
    */
   interface Config {
@@ -65,7 +86,9 @@ declare namespace Schmock {
     /** Unique plugin identifier */
     name: string
     /** Plugin version (semver) */
-    version: string
+    version?: string
+    /** Control execution order */
+    enforce?: 'pre' | 'post'
     
     /**
      * Called once when plugin is registered
@@ -74,57 +97,66 @@ declare namespace Schmock {
     setup?(core: Core): void | Promise<void>
     
     /**
-     * Called before request processing
-     * @param context - Request context
+     * Called before any data generation
+     * Can return data to short-circuit the pipeline
+     * @param context - Plugin context
+     * @returns Data to return immediately, or void to continue
      */
-    beforeRequest?(context: Context): void | Promise<void>
+    beforeGenerate?(context: PluginContext): any | void | Promise<any | void>
     
     /**
-     * Generate or transform response data
-     * @param context - Request context
-     * @returns Generated data
+     * Generate data when route has no configured data
+     * @param context - Plugin context
+     * @returns Generated data or void to pass to next plugin
      */
-    generate?(context: Context): any | Promise<any>
+    generate?(context: PluginContext): any | void | Promise<any | void>
     
     /**
-     * Post-process generated data
-     * @param context - Request context
-     * @param data - Generated data
-     * @returns Modified data
+     * Transform data (from route config or previous plugin)
+     * @param data - Current data
+     * @param context - Plugin context
+     * @returns Transformed data
      */
-    afterGenerate?(context: Context, data: any): any | Promise<any>
+    transform?(data: any, context: PluginContext): any | Promise<any>
     
     /**
-     * Called before sending response
-     * @param context - Request context with response
+     * Called before returning response (cannot modify data)
+     * @param data - Final data
+     * @param context - Plugin context
      */
-    beforeResponse?(context: Context & { response: Response }): void | Promise<void>
-    
-    /**
-     * Extend route configuration
-     * @param route - Original route config
-     * @returns Extended route config
-     */
-    extendRoute?(route: Route): Route
-    
-    /**
-     * Extend JSON schema
-     * @param schema - Original schema
-     * @returns Extended schema
-     */
-    extendSchema?(schema: import('json-schema').JSONSchema7): import('json-schema').JSONSchema7
+    beforeResponse?(data: any, context: PluginContext): void | Promise<void>
+  }
+  
+  /**
+   * Context passed through plugin pipeline
+   */
+  interface PluginContext {
+    /** Request path */
+    path: string
+    /** Matched route configuration */
+    route: Route
+    /** HTTP method (optional) */
+    method?: string
+    /** Route parameters */
+    params?: Record<string, string>
+    /** Shared state between plugins for this request */
+    state: Map<string, any>
   }
 
   /**
-   * Request context passed through plugin lifecycle
+   * Context for processing requests (used by standalone/HTTP implementations)
    */
-  interface Context {
-    /** Current request */
-    request: Request
-    /** Matched route configuration */
-    route: Route
-    /** Shared state between plugins for this request */
-    state: Record<string, any>
+  interface ProcessContext {
+    /** HTTP method */
+    method?: string
+    /** Request headers */
+    headers?: Record<string, string>
+    /** Request body */
+    body?: any
+    /** Query parameters */
+    query?: Record<string, string>
+    /** Path parameters */
+    params?: Record<string, string>
   }
 
   /**
@@ -136,23 +168,62 @@ declare namespace Schmock {
     /** Emitted when request processing ends */
     'request:end': { request: Request; response: Response }
     /** Emitted before data generation */
-    'generate:start': Context
+    'generate:start': PluginContext
     /** Emitted after data generation */
-    'generate:end': { context: Context; data: any }
+    'generate:end': { context: PluginContext; data: any }
     /** Emitted when plugin is registered */
     'plugin:registered': { plugin: Plugin }
     /** Emitted on errors */
-    'error': { error: Error; context?: Context }
+    'error': { error: Error; context?: PluginContext }
   }
 
   /**
-   * Core Schmock instance API
+   * Core Schmock orchestrator (no HTTP methods)
    */
-  interface Core {
+  interface CoreInstance {
     /**
      * Register a plugin
      * @param plugin - Plugin to register
      * @returns Self for chaining
+     */
+    use(plugin: Plugin): CoreInstance
+    
+    /**
+     * Process a request through the plugin pipeline
+     * @param path - Request path
+     * @param context - Processing context
+     * @returns Generated/transformed data
+     */
+    process(path: string, context?: ProcessContext): Promise<any>
+    
+    /**
+     * Subscribe to an event
+     * @param event - Event name
+     * @param handler - Event handler
+     */
+    on<K extends keyof EventMap>(event: K, handler: (data: EventMap[K]) => void): void
+    
+    /**
+     * Unsubscribe from an event
+     * @param event - Event name
+     * @param handler - Event handler to remove
+     */
+    off<K extends keyof EventMap>(event: K, handler: (data: EventMap[K]) => void): void
+    
+    /**
+     * Emit an event
+     * @param event - Event name
+     * @param data - Event data
+     */
+    emit<K extends keyof EventMap>(event: K, data: EventMap[K]): void
+  }
+
+  /**
+   * Schmock instance with HTTP methods (for backward compatibility)
+   */
+  interface Core extends CoreInstance {
+    /**
+     * Register a plugin (overrides return type for chaining)
      */
     use(plugin: Plugin): Core
     
@@ -222,5 +293,148 @@ declare namespace Schmock {
      * @param data - Event data
      */
     emit<K extends keyof EventMap>(event: K, data: EventMap[K]): void
+  }
+  
+  // ===== Fluent Builder API Types =====
+  
+  /**
+   * Configuration options for builder
+   */
+  interface BuilderConfig {
+    /** Base path prefix for all routes */
+    namespace?: string
+    /** Response delay in ms, or [min, max] for random delay */
+    delay?: number | [number, number]
+  }
+  
+  /**
+   * Context passed to response functions
+   */
+  interface ResponseContext<TState = any> {
+    /** Shared mutable state */
+    state: TState
+    /** Path parameters (e.g., :id) */
+    params: Record<string, string>
+    /** Query string parameters */
+    query: Record<string, string>
+    /** Request body (for POST, PUT, PATCH) */
+    body?: any
+    /** Request headers */
+    headers: Record<string, string>
+    /** HTTP method */
+    method: HttpMethod
+    /** Request path */
+    path: string
+  }
+  
+  /**
+   * Response function return types:
+   * - Any value: returns as 200 OK
+   * - [status, body]: custom status with body
+   * - [status, body, headers]: custom status, body, and headers
+   */
+  type ResponseResult = any | [number, any] | [number, any, Record<string, string>]
+  
+  /**
+   * Response function that handles requests
+   */
+  type ResponseFunction<TState = any> = (
+    context: ResponseContext<TState>
+  ) => ResponseResult | Promise<ResponseResult>
+  
+  /**
+   * Route definition for fluent API
+   */
+  interface RouteDefinition<TState = any> {
+    /**
+     * Function that generates the response
+     */
+    response: ResponseFunction<TState>
+    
+    /**
+     * Plugin extensions (validation, middleware, etc.)
+     */
+    [key: string]: any
+  }
+  
+  /**
+   * Routes configuration using 'METHOD /path' keys
+   */
+  type Routes<TState = any> = {
+    [K in RouteKey]?: RouteDefinition<TState>
+  }
+  
+  /**
+   * Fluent builder interface
+   */
+  interface Builder<TState = any> {
+    /**
+     * Configure mock options
+     * 
+     * @example
+     * schmock().config({ namespace: '/api/v1', delay: [100, 500] })
+     */
+    config(options: BuilderConfig): Builder<TState>
+    
+    /**
+     * Define routes using 'METHOD /path' keys
+     * 
+     * @example
+     * ```typescript
+     * schmock()
+     *   .routes({
+     *     'GET /users': { 
+     *       response: ({ state }) => state.users 
+     *     },
+     *     'POST /users': { 
+     *       response: ({ body, state }) => {
+     *         const user = { id: Date.now(), ...body }
+     *         state.users.push(user)
+     *         return [201, user]
+     *       }
+     *     }
+     *   })
+     * ```
+     */
+    routes(routes: Routes<TState>): Builder<TState>
+    
+    /**
+     * Set initial shared state
+     * 
+     * @example
+     * schmock().state({ users: [], posts: [] })
+     */
+    state<T>(initial: T): Builder<T>
+    
+    /**
+     * Register a plugin
+     */
+    use(plugin: Plugin): Builder<TState>
+    
+    /**
+     * Build the mock instance
+     */
+    build(): MockInstance<TState>
+  }
+  
+  /**
+   * Built mock instance
+   */
+  interface MockInstance<TState = any> {
+    /**
+     * Handle a request (for testing or adapters)
+     * 
+     * @example
+     * const response = await mock.handle('GET', '/users')
+     */
+    handle(method: HttpMethod, path: string, options?: {
+      headers?: Record<string, string>
+      body?: any
+      query?: Record<string, string>
+    }): Promise<{
+      status: number
+      body: any
+      headers: Record<string, string>
+    }>
   }
 }


### PR DESCRIPTION
- Add new @schmock/builder package with fluent API
- Use 'METHOD /path' route key format for better DX
- Support dynamic responses, state management, and custom status codes
- Implement with full TDD: parser tests, builder tests, and BDD features
- Add comprehensive TypeScript types in ambient namespace
- Support route parameters, query strings, headers, and namespaces
- All 101 tests passing (30 unit + 71 BDD)